### PR TITLE
:memo:添加管理员获取所有课程的接口文档

### DIFF
--- a/openapi/cloudapi_v2.yaml
+++ b/openapi/cloudapi_v2.yaml
@@ -439,6 +439,24 @@ paths:
       description: 获取课程信息
       security:
         - Authorization: []
+  '/courses':
+    get:
+      summary: 管理员获取所有课程
+      tags:
+        - 课程
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CourseResponse'
+      operationId: get-course-list
+      security:
+        - Authorization: [ ]
+      description: 管理员获取所有课程
   '/stat/exp/{expId}/assignments':
     parameters:
       - schema:


### PR DESCRIPTION
该接口需要返回全部课程
sql语句如下：
```sql
SELECT c.id 'id', c.name 'name', u.name 'teacher', t.id 'term.id', t.name 'term.name', c.create_time 'createTime', d.name 'departmentId', 0 'studentCnt'
 FROM term t, department d, course c, user u 
WHERE t.id=c.term_id AND d.id=c.department_id AND c.teacher_id=u.id;
```
其中，在cloudapi的CourseResponse类中需要填写学生人数，本接口不需要此信息，值为0即可