### PR TITLE
Can choose whether or not to count the number of students

### DIFF
--- a/openapi/cloudapi_v2.yaml
+++ b/openapi/cloudapi_v2.yaml
@@ -2497,7 +2497,6 @@ components:
         - term
         - createTime
         - departmentId
-        - studentCnt
     AssignmentListResponse:
       title: AssignmentListResponse
       type: object

--- a/src/main/kotlin/cn/edu/buaa/scs/route/Course.kt
+++ b/src/main/kotlin/cn/edu/buaa/scs/route/Course.kt
@@ -18,7 +18,7 @@ fun Route.courseRoute() {
 
     route("/courses") {
         get {
-            call.respond(call.course.getAllCourses().map { call.convertCourseResponse(it) })
+            call.respond(call.course.getAllCourses().map { call.convertCourseResponse(it, false) })
         }
     }
 
@@ -30,7 +30,7 @@ fun Route.courseRoute() {
         get {
             val courseId = call.getCourseIdFromPath()
             val course = call.course.get(courseId)
-            call.respond(call.convertCourseResponse(course))
+            call.respond(call.convertCourseResponse(course, true))
         }
 
         route("/resource") {
@@ -76,7 +76,7 @@ fun Route.courseRoute() {
 
 }
 
-internal fun ApplicationCall.convertCourseResponse(course: Course): CourseResponse {
+internal fun ApplicationCall.convertCourseResponse(course: Course, hasCount: Boolean): CourseResponse {
     return CourseResponse(
         id = course.id,
         name = course.name,
@@ -84,7 +84,7 @@ internal fun ApplicationCall.convertCourseResponse(course: Course): CourseRespon
         term = convertTermModel(course.term),
         createTime = course.createTime,
         departmentId = course.departmentId,
-        studentCnt = this.course.studentCnt(course.id)
+        studentCnt = if(hasCount) this.course.studentCnt(course.id) else 0
     )
 }
 

--- a/src/main/kotlin/cn/edu/buaa/scs/route/Experiment.kt
+++ b/src/main/kotlin/cn/edu/buaa/scs/route/Experiment.kt
@@ -161,7 +161,7 @@ internal fun convertExperimentResponse(call: ApplicationCall, experiment: Experi
         peerAssessmentRules = experiment.peerAssessmentRules,
         peerAssessmentStart = experiment.peerAssessmentStart,
         sentEmail = experiment.sentEmail,
-        course = call.convertCourseResponse(experiment.course),
+        course = call.convertCourseResponse(experiment.course, true),
         vm = experiment.getVmApply()?.let { convertExpVmInfo(it) },
     )
 

--- a/src/main/kotlin/cn/edu/buaa/scs/route/Stat.kt
+++ b/src/main/kotlin/cn/edu/buaa/scs/route/Stat.kt
@@ -95,7 +95,7 @@ internal fun convertStatCourseExpsResponse(
     source: CourseService.StatCourseExps
 ): StatCourseExpsResponse {
     return StatCourseExpsResponse(
-        course = call.convertCourseResponse(source.course),
+        course = call.convertCourseResponse(source.course, true),
         teacher = convertUserModel(source.teacher),
         studentCnt = source.studentCnt,
         exps = source.expDetails.map { convertStatCourseExp(it) }


### PR DESCRIPTION
Because the `convertCourseResponse` function has one SQL query in it, using this function on the course list would result in O(n) SQL queries, so you can choose whether or not to execute it.
```kotlin
internal fun ApplicationCall.convertCourseResponse(course: Course, hasCount: Boolean): CourseResponse { 
    return CourseResponse( 
        id = course.id,
         name = course.name, 
        teacher = course.teacher.name, 
        term = convertTermModel(course.term), 
        createTime = course.createTime, 
        departmentId = course.departmentId, 
        studentCnt = if(hasCount) this.course.studentCnt(course.id) else 0
     )
 }
```